### PR TITLE
Change Password - manage validation and state #139

### DIFF
--- a/app/containers/ChangePassword/actions.js
+++ b/app/containers/ChangePassword/actions.js
@@ -13,7 +13,8 @@ import {
   UPDATE_SINGLE_INPUT_FIELD,
   UPDATE_SINGLE_ERROR_FIELD,
   UPDATE_IS_PASSWORD_UPDATED,
-  UPDATE_IS_PASSWORD_WRONG
+  UPDATE_IS_PASSWORD_WRONG,
+  RESET_STATE
 } from './constants'
 
 
@@ -55,6 +56,12 @@ export function updateIsPasswordWrong(status) {
   return {
     type: UPDATE_IS_PASSWORD_WRONG,
     status
+  };
+}
+
+export function resetState() {
+  return {
+    type: RESET_STATE
   };
 }
 

--- a/app/containers/ChangePassword/constants.js
+++ b/app/containers/ChangePassword/constants.js
@@ -2,3 +2,4 @@ export const UPDATE_SINGLE_INPUT_FIELD = 'app/containers/ChangePassword/UPDATE_S
 export const UPDATE_SINGLE_ERROR_FIELD = 'app/containers/ChangePassword/UPDATE_SINGLE_ERROR_FIELD';
 export const UPDATE_IS_PASSWORD_UPDATED = 'app/containers/ChangePassword/UPDATE_IS_PASSWORD_UPDATED';
 export const UPDATE_IS_PASSWORD_WRONG = 'app/containers/ChangePassword/UPDATE_IS_PASSWORD_WRONG';
+export const RESET_STATE = 'app/containers/ChangePassword/RESET_STATE';

--- a/app/containers/ChangePassword/index.js
+++ b/app/containers/ChangePassword/index.js
@@ -17,7 +17,7 @@ import {
   Title
 } from 'native-base';
 import { Actions } from 'react-native-router-flux';
-import { StyleSheet, Alert } from 'react-native';
+import { StyleSheet, Alert, View } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import styles from './styles';
 import InputItem from '../../components/InputItem';
@@ -113,10 +113,18 @@ class ChangePassword extends Component {
               :
               null
             }
-            {(current_password === '' || new_password === '' || confirm_password === '') ?
-              <Button disabled block style={[ styles.button, { elevation: 0 } ]}>
-                <Text style={styles.buttomText}>Change Password</Text>
-              </Button>
+            {(current_password === '' || new_password === '' || confirm_password === '' || new_password !== confirm_password) ?
+              <View>
+                { ((new_password !== confirm_password)  ) ?
+                  <Text style={styles.newPassValidator}>"both new password doesn't match"</Text>
+                  :
+                  null
+                }
+                <Button disabled block style={[ styles.button, { elevation: 0 } ]}>
+                  <Text style={styles.buttomText}>Change Password</Text>
+                </Button>
+
+              </View>
               :
               <Button primary block style={styles.button} onPress={() => {return this.submitChangePassword()}}>
                 <Text style={styles.buttomText}>Change Password</Text>

--- a/app/containers/ChangePassword/index.js
+++ b/app/containers/ChangePassword/index.js
@@ -90,6 +90,7 @@ class ChangePassword extends Component {
               secureTextEntry
               onChangeText={text => {return this.handleInputChange('current_password', text)}}
               value={current_password}
+              placeholder="Current Password"
             />
             <InputItem
               error={error_new_password}
@@ -97,6 +98,7 @@ class ChangePassword extends Component {
               secureTextEntry
               onChangeText={text => {return this.handleInputChange('new_password', text)}}
               value={new_password}
+              placeholder="New Password"
             />
             <InputItem
               error={error_confirm_password}
@@ -104,6 +106,7 @@ class ChangePassword extends Component {
               secureTextEntry
               onChangeText={text => {return this.handleInputChange('confirm_password', text)}}
               value={confirm_password}
+              placeholder="Confirm New Password"
             />
             {error_password_not_the_same ?
               <Text style={styles.newPassValidator}>Confirm password didn't match</Text>

--- a/app/containers/ChangePassword/index.js
+++ b/app/containers/ChangePassword/index.js
@@ -106,6 +106,16 @@ class ChangePassword extends Component {
               value={new_password}
               placeholder="New Password"
             />
+            { ((new_password.length < 6) && new_password !== '') ?
+              <Text style={styles.newPassValidator}>new password should be 6 at minimum</Text>
+              :
+              null
+            }
+            { ((current_password === new_password) && current_password !== '') ?
+              <Text style={styles.newPassValidator}>current and new password can't be same</Text>
+              :
+              null
+            }
             <InputItem
               error={error_confirm_password}
               title="Confirm New Password"
@@ -114,31 +124,25 @@ class ChangePassword extends Component {
               value={confirm_password}
               placeholder="Confirm New Password"
             />
+            { ((confirm_password.length < 6) && (confirm_password !== '') && (new_password < 6)) ?
+              <Text style={styles.newPassValidator}>confirm password should be 6 at minimum</Text>
+              :
+              null
+            }
             {error_password_not_the_same ?
               <Text style={styles.newPassValidator}>Confirm password didn't match</Text>
               :
               null
             }
+            { ((new_password !== confirm_password) && confirm_password !== ''  ) ?
+              <View>
+              <Text style={styles.newPassValidator}>both new password doesn't match</Text>
+              </View>
+              :
+              null
+            }
             {(current_password === '' || new_password === '' || confirm_password === '' || new_password !== confirm_password || new_password.length < 6 || confirm_password < 6 || current_password < 6 || current_password === new_password) ?
               <View>
-                { ((new_password !== confirm_password)  ) ?
-                  <View>
-                  <Text style={styles.newPassValidator}>"both new password doesn't match"</Text>
-                  { ((new_password.length < 6)) ?
-                    <Text style={styles.newPassValidator}>"new password should be 6 at minimum"</Text>
-                    :
-                    null
-                  }
-                  { ((current_password === new_password)) ?
-                    <Text style={styles.newPassValidator}>"current and new password can't be same"</Text>
-                    :
-                    null
-                  }
-                  </View>
-                  :
-                  null
-                }
-
                 <Button disabled block style={[ styles.button, { elevation: 0 } ]}>
                   <Text style={styles.buttomText}>Change Password</Text>
                 </Button>

--- a/app/containers/ChangePassword/index.js
+++ b/app/containers/ChangePassword/index.js
@@ -113,13 +113,18 @@ class ChangePassword extends Component {
               :
               null
             }
-            {(current_password === '' || new_password === '' || confirm_password === '' || new_password !== confirm_password || new_password.length < 6 || confirm_password < 6 || current_password < 6) ?
+            {(current_password === '' || new_password === '' || confirm_password === '' || new_password !== confirm_password || new_password.length < 6 || confirm_password < 6 || current_password < 6 || current_password === new_password) ?
               <View>
                 { ((new_password !== confirm_password)  ) ?
                   <View>
                   <Text style={styles.newPassValidator}>"both new password doesn't match"</Text>
                   { ((new_password.length < 6)) ?
                     <Text style={styles.newPassValidator}>"new password should be 6 at minimum"</Text>
+                    :
+                    null
+                  }
+                  { ((current_password === new_password)) ?
+                    <Text style={styles.newPassValidator}>"current and new password can't be same"</Text>
                     :
                     null
                   }

--- a/app/containers/ChangePassword/index.js
+++ b/app/containers/ChangePassword/index.js
@@ -113,13 +113,21 @@ class ChangePassword extends Component {
               :
               null
             }
-            {(current_password === '' || new_password === '' || confirm_password === '' || new_password !== confirm_password) ?
+            {(current_password === '' || new_password === '' || confirm_password === '' || new_password !== confirm_password || new_password.length < 6 || confirm_password < 6 || current_password < 6) ?
               <View>
                 { ((new_password !== confirm_password)  ) ?
+                  <View>
                   <Text style={styles.newPassValidator}>"both new password doesn't match"</Text>
+                  { ((new_password.length < 6)) ?
+                    <Text style={styles.newPassValidator}>"new password should be 6 at minimum"</Text>
+                    :
+                    null
+                  }
+                  </View>
                   :
                   null
                 }
+
                 <Button disabled block style={[ styles.button, { elevation: 0 } ]}>
                   <Text style={styles.buttomText}>Change Password</Text>
                 </Button>

--- a/app/containers/ChangePassword/index.js
+++ b/app/containers/ChangePassword/index.js
@@ -65,6 +65,10 @@ class ChangePassword extends Component {
       }
     }
 
+    componentWillUnmount() {
+      this.props.resetState()
+    }
+
     render() {
       // destructure state
       const { inputFields, errorFields, isPasswordUpdated, isPasswordWrong } = this.props || {};
@@ -80,6 +84,8 @@ class ChangePassword extends Component {
         Alert.alert('Fail', 'Please make sure you input the right password');
         this.props.updateIsPasswordWrong(false)
       }
+
+
 
       return (
         <Container style={styles.container}>

--- a/app/containers/ChangePassword/reducer.js
+++ b/app/containers/ChangePassword/reducer.js
@@ -8,7 +8,8 @@ import {
   UPDATE_SINGLE_INPUT_FIELD,
   UPDATE_SINGLE_ERROR_FIELD,
   UPDATE_IS_PASSWORD_UPDATED,
-  UPDATE_IS_PASSWORD_WRONG
+  UPDATE_IS_PASSWORD_WRONG,
+  RESET_STATE
 } from './constants';
 
 /*
@@ -43,6 +44,9 @@ function changePasswordReducer(state = initialState, action) {
 
     case UPDATE_IS_PASSWORD_WRONG:
       return state.set('isPasswordWrong', action.status);
+
+    case RESET_STATE:
+      return initialState;
 
     default:
       return state;


### PR DESCRIPTION
#139 FIx


### Breakdown:
- [x] show placeholder on change password input
- [x] button should be disabled if both new password doesn't match and show the user what's wrong
- [x] password validation on change password, minimum length, old & new can't be same
- [x] reset the fields after change password